### PR TITLE
fix: update deprecated xblockutils to xblock-utils

### DIFF
--- a/jupyterxblock/xblock.py
+++ b/jupyterxblock/xblock.py
@@ -5,7 +5,12 @@ import urllib.parse
 from django.conf import settings
 from lti_consumer.lti_xblock import LtiConsumerXBlock, _
 from xblock.core import Scope, String, XBlock
-from xblockutils.resources import ResourceLoader
+
+try:
+     from xblock.utils.resources import ResourceLoader
+ except ModuleNotFoundError: # For backward compatibility with releases older than Quince.
+     from xblockutils.resources import ResourceLoader
+ 
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
The xblock-utils package has been [deprecated](https://github.com/openedx/XBlock/issues/675) and moved into the xblock package. Therefore, we add a try catch to make this xblock compatible with new releases and with older ones as well.